### PR TITLE
fix(cli): scopes must match identifier_uris in tf example

### DIFF
--- a/go-cli/main.go
+++ b/go-cli/main.go
@@ -37,7 +37,7 @@ func main() {
 	tenantID := "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	clientID := "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
-	scopes := "api://term/access"
+	scopes := "api://termpad/access"
 
 	pkce, err := oauth2params.NewPKCE()
 	if err != nil {


### PR DESCRIPTION
error: The resource principal named api://term was not found in the tenant named xxxxxxx. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant.

